### PR TITLE
chore(deps-dev): bump @biomejs/biome to 2.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@biomejs/biome": "1.9.4"
+    "@biomejs/biome": "2.0.0-beta.1"
   }
 }


### PR DESCRIPTION
Fails with the following error

```console
Run biomejs/setup-biome@v2
No working directory specified. Using the current working directory.
GET /repos/biomejs/biome/releases/tags/cli%2Fv2.0.0-beta.1 - [4](https://github.com/trivikr/test-setup-biome-v2.0.0-beta.1/actions/runs/14074483232/job/39414883741?pr=2#step:3:5)04 with id 8841:3442D2:1BAE3BB:37A4AFA:67E36CBE in 298ms
Version 2.0.0-beta.1 of the Biome CLI does not exist.
Error: Version 2.0.0-beta.1 of the Biome CLI does not exist.
```

https://github.com/trivikr/test-setup-biome-v2.0.0-beta.1/actions/runs/14074483232/job/39414883741?pr=2
